### PR TITLE
ci: stop pinning pnpm to v10 (fixes 6h frontend-test timeout)

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
-          version: 10
+          package_json_file: ./etherpad-lite/package.json
           run_install: false
       - name: Get pnpm store directory
         shell: bash

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
-          version: 10
+          package_json_file: ./etherpad-lite/package.json
           run_install: false
       - name: Get pnpm store directory
         shell: bash

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -34,7 +34,6 @@ jobs:
       - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
-          version: 10
           run_install: false
       - name: Get pnpm store directory
         shell: bash


### PR DESCRIPTION
## Problem

Every `Node.js Package` run on this repo has been **cancelled at the 6-hour job limit since ~May** — including the current Dependabot checkout bump #89. The frontend job runs the full core `test-ui` suite, and **every** spec (the plugin's own `define.spec.ts` *and* core specs like `a11y_dialogs`/`rtl_url_param`) fails identically:

```
page.waitForSelector: Test timeout of 90000ms exceeded.
waiting for locator('iframe[name="ace_outer"]') to be visible
```

The editor iframe never renders, so all ~hundreds of specs burn 90s × retries until the job is cancelled.

## Root cause

The workflows pin `pnpm/action-setup` to `version: 10`, but Etherpad core declares `packageManager: pnpm@11.1.2`. The CI log shows the forced downgrade:

```
Switching pnpm from v11.7.0 to v10.34.3...
```

Under that mismatch the backgrounded `pnpm run dev` server's lazy frontend build never produces a working editor bundle (the `curl /` readiness probe still passes because the landing page doesn't need the build), so every pad load times out.

This is **not** caused by #89's `actions/checkout` v6→v7 bump — that PR is just the latest victim. Verified by correlation across the fleet: **every** `ether/*` plugin that reads etherpad's pin via `package_json_file` (ep_align, ep_font_color, ep_headings2, ep_font_size, ep_cursortrace …) passes its frontend job in ~4 min; ep_define is the **only** one still on `version: 10` and the **only** one cancelled at 6h. Locally, the editor loads fine with ep_define installed under pnpm 11.

## Fix

Match the rest of the fleet:
- **frontend / backend** jobs (core checked out at `./etherpad-lite`): `package_json_file: ./etherpad-lite/package.json`
- **publish** job (core checked out at repo root): drop `version:` and let `action-setup` auto-detect

After this lands, rebase #89 (`@dependabot rebase`) and it should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)